### PR TITLE
Fix warnings with gcc 4.4 in C++11 mode

### DIFF
--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -149,7 +149,13 @@ struct types_when_isnt_ref
   typedef T &      reference_type ;
 #ifndef  BOOST_NO_CXX11_RVALUE_REFERENCES
   typedef T &&     rval_reference_type ;
+#ifdef BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+  // GCC 4.4 has support for an early draft of rvalue references. The conforming version below
+  // causes warnings about returning references to a temporary.
+  static T&& move(T&& r) { return r; }
+#else
   static rval_reference_type move(reference_type r) { return boost::move(r); }
+#endif
 #endif
   typedef T const* pointer_const_type ;
   typedef T *      pointer_type ;


### PR DESCRIPTION
GCC 4.4 has support for an early draft of rvalue references. When compiling the conforming code it produces warnings such as '../boost/optional/optional.hpp:152: warning: returning reference to temporary'. In order to fix this regression use a special implementation of move(), similar to std::move() on this compiler.
