### PR TITLE
Semantic fix for operator<<

### DIFF
--- a/include/boost/optional/optional_io.hpp
+++ b/include/boost/optional/optional_io.hpp
@@ -50,7 +50,7 @@ operator>>(std::basic_istream<CharType, CharTrait>& in, optional<T>& v)
   }
   else
   {
-	  // unset failbit, because extraction succeeded...
+    // unset failbit, because extraction succeeded...
     in.clear(before & ~std::ios::failbit);
     // but there is no value
     v.reset();


### PR DESCRIPTION
operator<<(std::ostream&, optional<T> const& o) should do nothing if "o" is not engaged (has no value), instead of printing ' --'.
