### PR TITLE
Supply <string> to fix C++03 compile error on logic_error("...")

### DIFF
--- a/include/boost/optional/bad_optional_access.hpp
+++ b/include/boost/optional/bad_optional_access.hpp
@@ -13,6 +13,9 @@
 #define BOOST_BAD_OPTIONAL_ACCESS_22MAY2014_HPP
 
 #include <stdexcept>
+#if __cplusplus < 201103L
+#include <string> // to make converting-ctor std::string(char const*) visible
+#endif
 
 namespace boost {
 


### PR DESCRIPTION
This change makes the library usable (again) on C++03 standard library
implementations where <stdexcept> doesn't imply inclusion of <string>,
e.g. STLport.
