### PR TITLE
Add operator<< for boost::none

### DIFF
--- a/include/boost/optional/optional_io.hpp
+++ b/include/boost/optional/optional_io.hpp
@@ -23,6 +23,15 @@
 namespace boost
 {
 
+template<class CharType, class CharTrait>
+inline
+std::basic_ostream<CharType, CharTrait>&
+operator<<(std::basic_ostream<CharType, CharTrait>& out, none_t const&)
+{
+    out << "--";
+    return out;
+}
+
 template<class CharType, class CharTrait, class T>
 inline
 std::basic_ostream<CharType, CharTrait>&

--- a/test/optional_test_io.cpp
+++ b/test/optional_test_io.cpp
@@ -75,12 +75,22 @@ void test( T v, T w )
   test2( optional<T>  () , make_optional(w));
 }
 
+void
+test()
+{
+    stringstream s ;
+    s << boost::none;
+    BOOST_ASSERT(s.str() == "--");
+}
+
+
 int test_main( int, char* [] )
 {
   try
   {
     test(1,2);
     test(string("hello"),string("buffer"));
+    test();
   }
   catch ( ... )
   {


### PR DESCRIPTION
The new definition of none_t inhibits conversion to nullptr.This leads to errors if none is output to a stream, like Boost.Test diagnostics output.
Add the missing operator plus testcase.
