### PR TITLE
Fix build issues when optional_fwd.hpp is used before including boost/config.hpp

### DIFF
--- a/include/boost/optional/optional_fwd.hpp
+++ b/include/boost/optional/optional_fwd.hpp
@@ -16,7 +16,7 @@
 #ifndef BOOST_OPTIONAL_OPTIONAL_FWD_FLC_19NOV2002_HPP
 #define BOOST_OPTIONAL_OPTIONAL_FWD_FLC_19NOV2002_HPP
 
-#include <boost/config/suffix.hpp>
+#include <boost/config.hpp>
 
 namespace boost {
 


### PR DESCRIPTION
Fixes https://svn.boost.org/trac/boost/ticket/12179