### PR TITLE
Fix Operator!= none_t Return Statement

### DIFF
--- a/doc/28_ref_optional_semantics.qbk
+++ b/doc/28_ref_optional_semantics.qbk
@@ -1181,7 +1181,7 @@ __SPACE__
 [: `bool operator != ( optional<T> const& x, none_t ) noexcept;`]
 [: `bool operator != ( none_t, optional<T> const& x ) noexcept;`]
 
-* [*Returns: ] `!( x == y );`
+* [*Returns: ] `bool(x);`
 
 
 __SPACE__


### PR DESCRIPTION
The 'Returns' statement for operator!=(optional, none_t) shows a copy from operator!=(optional, optional) instead of the proper return value.