### PR TITLE
Fix gcc warnings about data which may be used unitialized.

### DIFF
--- a/include/boost/optional/detail/optional_aligned_storage.hpp
+++ b/include/boost/optional/detail/optional_aligned_storage.hpp
@@ -32,6 +32,9 @@ class aligned_storage
 #endif
     dummy_u
     {
+        // empty_initiliazer_ is used only to shut down gcc warnings about
+        // data "may be used unitialized"
+        char empty_initiliazer_;
         char data[ sizeof(T) ];
         BOOST_DEDUCED_TYPENAME type_with_alignment<
           ::boost::alignment_of<T>::value >::type aligner_;
@@ -46,6 +49,11 @@ class aligned_storage
     void const* address() const { return dummy_.data; }
     void      * address()       { return dummy_.data; }
 #endif
+
+    void construct_empty()
+    {
+        dummy_.empty_initiliazer_ = '\0';
+    }
 
 #if defined(BOOST_OPTIONAL_DETAIL_USE_ATTRIBUTE_MAY_ALIAS)
 	// This workaround is supposed to silence GCC warnings about broken strict aliasing rules

--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -89,13 +89,19 @@ class optional_base : public optional_tag
     // No-throw
     optional_base()
       :
-      m_initialized(false) {}
+      m_initialized(false)
+    {
+      construct_empty();
+    }
 
     // Creates an optional<T> uninitialized.
     // No-throw
     optional_base ( none_t )
       :
-      m_initialized(false) {}
+      m_initialized(false)
+    {
+      construct_empty();
+    }
 
     // Creates an optional<T> initialized with 'val'.
     // Can throw if T::T(T const&) does
@@ -125,6 +131,8 @@ class optional_base : public optional_tag
     {
       if ( cond )
         construct(val);
+      else
+        construct_empty();
     }
 
     // Creates a deep copy of another optional<T>
@@ -135,6 +143,8 @@ class optional_base : public optional_tag
     {
       if ( rhs.is_initialized() )
         construct(rhs.get_impl());
+      else
+        construct_empty();
     }
 
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
@@ -146,6 +156,8 @@ class optional_base : public optional_tag
     {
       if ( rhs.is_initialized() )
         construct( boost::move(rhs.get_impl()) );
+      else
+        construct_empty();
     }
 #endif
 
@@ -319,6 +331,11 @@ class optional_base : public optional_tag
     bool is_initialized() const { return m_initialized ; }
 
   protected :
+
+    void construct_empty ()
+     {
+      m_storage.construct_empty();
+     }
 
     void construct ( argument_type val )
      {


### PR DESCRIPTION
Hi,

This is an attempt to fix the warnings raised by gcc 6 about the data pointer which may be used uninitialized. The corresponding Boost ticket is https://svn.boost.org/trac/boost/ticket/12513.

I checked the code and it looks like this is a gcc false positive. I have opened a gcc ticket here https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78044 where apparently it looks like these are longstanding gcc false positive bugs, which apparently are hard to fix on the compiler side.

So here is a proposal to workaround that on boost side, by making sure that at least one field of the optional storage is being initialized, to "trick" gcc. This will come at the extense of one more (useless) initialization of 1 byte each time the constructor of boost::optional is called without any initializing value, and if the compiler cannot tell for sure that it will later be initialized (we can expect the dummy empty initialization to be optimized out by the compiler if for sure the value is overriden later).

Are you OK with the principle of this fix ?

Cheers,
Romain
