### PR TITLE
Adds forwarding make_optional helpers, resolves #30

### DIFF
--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -1276,6 +1276,25 @@ class optional<T&&>
 
 namespace boost {
 
+#ifndef BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
+
+template<class T>
+inline
+optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type> make_optional ( T && v  )
+{
+  return optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type>(boost::forward<T>(v));
+}
+
+// Returns optional<T>(cond,v)
+template<class T>
+inline
+optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type> make_optional ( bool cond, T && v )
+{
+  return optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type>(cond,boost::forward<T>(v));
+}
+
+#else
+
 // Returns optional<T>(v)
 template<class T>
 inline
@@ -1291,6 +1310,8 @@ optional<T> make_optional ( bool cond, T const& v )
 {
   return optional<T>(cond,v);
 }
+
+#endif // BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
 
 // Returns a reference to the value if this is initialized, otherwise, the behaviour is UNDEFINED.
 // No-throw


### PR DESCRIPTION
For #30. The varargs overloads probably make no sense with the `bool` argument at the second position?

I don't quite understand why the `test/optional_test_fail_copying_a_moveable_type.cpp` fails to compile [here](https://github.com/boostorg/optional/blob/cb7641dc34bc61cefa44e9bccfebe02889148528/include/boost/optional/optional.hpp#L350) (unrelated to this changeset) - shouldn't construction from a moveable-only type work?

Also how can I provide docs for the overload depending on if rvalue refs are enabled or not? I found the quickbook files in `doc`  I'm just wondering what the best way to document the overloads is.

cc @akrzemi1 