### PR TITLE
Use BOOST_MAY_ALIAS from Boost.Config

### DIFF
--- a/include/boost/optional/detail/old_optional_implementation.hpp
+++ b/include/boost/optional/detail/old_optional_implementation.hpp
@@ -746,12 +746,12 @@ class optional : public optional_detail::optional_base<T>
     optional ( optional const& rhs ) : base( static_cast<base const&>(rhs) ) {}
 
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
-	// Creates a deep move of another optional<T>
-	// Can throw if T::T(T&&) does
-	optional ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
-	  : base( boost::move(rhs) ) 
-	{}
+    // Creates a deep move of another optional<T>
+    // Can throw if T::T(T&&) does
+    optional ( optional && rhs )
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
+      : base( boost::move(rhs) )
+    {}
 
 #endif
    // No-throw (assuming T::~T() doesn't)
@@ -819,7 +819,7 @@ class optional : public optional_detail::optional_base<T>
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Assigns from another optional<T> (deep-moves the rhs value)
     optional& operator= ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         this->assign( static_cast<base &&>(rhs) ) ;
         return *this ;
@@ -892,7 +892,7 @@ class optional : public optional_detail::optional_base<T>
 #endif
 
     void swap( optional & arg )
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         // allow for Koenig lookup
         boost::swap(*this, arg);

--- a/include/boost/optional/detail/optional_aligned_storage.hpp
+++ b/include/boost/optional/detail/optional_aligned_storage.hpp
@@ -25,12 +25,8 @@ template <class T>
 class aligned_storage
 {
     // Borland ICEs if unnamed unions are used for this!
-    union
-    // This works around GCC warnings about breaking strict aliasing rules when casting storage address to T*
-#if defined(BOOST_OPTIONAL_DETAIL_USE_ATTRIBUTE_MAY_ALIAS)
-    __attribute__((__may_alias__))
-#endif
-    dummy_u
+    // BOOST_MAY_ALIAS works around GCC warnings about breaking strict aliasing rules when casting storage address to T*
+    union BOOST_MAY_ALIAS dummy_u
     {
         char data[ sizeof(T) ];
         BOOST_DEDUCED_TYPENAME type_with_alignment<

--- a/include/boost/optional/detail/optional_aligned_storage.hpp
+++ b/include/boost/optional/detail/optional_aligned_storage.hpp
@@ -44,24 +44,24 @@ class aligned_storage
 #endif
 
 #if defined(BOOST_OPTIONAL_DETAIL_USE_ATTRIBUTE_MAY_ALIAS)
-	// This workaround is supposed to silence GCC warnings about broken strict aliasing rules
-	T const* ptr_ref() const
-	{
-		union { void const* ap_pvoid; T const* as_ptype; } caster = { address() };
-		return caster.as_ptype;
-	}
-	T *      ptr_ref()
-	{
-		union { void* ap_pvoid; T* as_ptype; } caster = { address() };
-		return caster.as_ptype;
-	}
+    // This workaround is supposed to silence GCC warnings about broken strict aliasing rules
+    T const* ptr_ref() const
+    {
+        union { void const* ap_pvoid; T const* as_ptype; } caster = { address() };
+        return caster.as_ptype;
+    }
+    T *      ptr_ref()
+    {
+        union { void* ap_pvoid; T* as_ptype; } caster = { address() };
+        return caster.as_ptype;
+    }
 #else
-	T const* ptr_ref() const { return static_cast<T const*>(address()); }
-	T *      ptr_ref()       { return static_cast<T *>     (address()); }
+    T const* ptr_ref() const { return static_cast<T const*>(address()); }
+    T *      ptr_ref()       { return static_cast<T *>     (address()); }
 #endif
 
-	T const& ref() const { return *ptr_ref(); }
-	T &      ref()       { return *ptr_ref(); }
+    T const& ref() const { return *ptr_ref(); }
+    T &      ref()       { return *ptr_ref(); }
   
 } ;
 

--- a/include/boost/optional/detail/optional_config.hpp
+++ b/include/boost/optional/detail/optional_config.hpp
@@ -44,11 +44,11 @@
 # define BOOST_OPTIONAL_WEAK_OVERLOAD_RESOLUTION
 #endif
 
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-// GCC since 3.3 has may_alias attribute that helps to alleviate optimizer issues with
-// regard to violation of the strict aliasing rules. The optional< T > storage type is marked
-// with this attribute in order to let the compiler know that it will alias objects of type T
-// and silence compilation warnings.
+#if !defined(BOOST_NO_MAY_ALIAS)
+// GCC since 3.3 and some other compilers have may_alias attribute that helps to alleviate
+// optimizer issues with regard to violation of the strict aliasing rules. The optional< T >
+// storage type is marked with this attribute in order to let the compiler know that it will
+// alias objects of type T and silence compilation warnings.
 # define BOOST_OPTIONAL_DETAIL_USE_ATTRIBUTE_MAY_ALIAS
 #endif
 

--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -67,7 +67,7 @@ struct in_place_init_t
 };            
 const in_place_init_t in_place_init ((in_place_init_t::init_tag()));
 
-// a tag for conditional in-place initialization of contained value	
+// a tag for conditional in-place initialization of contained value
 struct in_place_init_if_t
 {
   struct init_tag{};
@@ -896,12 +896,12 @@ class optional : public optional_detail::optional_base<T>
     optional ( optional const& rhs ) : base( static_cast<base const&>(rhs) ) {}
 
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
-	// Creates a deep move of another optional<T>
-	// Can throw if T::T(T&&) does
-	optional ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
-	  : base( boost::move(rhs) ) 
-	{}
+    // Creates a deep move of another optional<T>
+    // Can throw if T::T(T&&) does
+    optional ( optional && rhs )
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
+      : base( boost::move(rhs) )
+    {}
 
 #endif
 
@@ -910,7 +910,7 @@ class optional : public optional_detail::optional_base<T>
     ~optional() {}
 #endif
 
-	
+
 #if !defined(BOOST_OPTIONAL_NO_INPLACE_FACTORY_SUPPORT) && !defined(BOOST_OPTIONAL_WEAK_OVERLOAD_RESOLUTION)
     // Assigns from an expression. See corresponding constructor.
     // Basic Guarantee: If the resolved T ctor throws, this is left UNINITIALIZED
@@ -968,7 +968,7 @@ class optional : public optional_detail::optional_base<T>
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Assigns from another optional<T> (deep-moves the rhs value)
     optional& operator= ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         this->assign( static_cast<base &&>(rhs) ) ;
         return *this ;
@@ -1112,7 +1112,7 @@ class optional : public optional_detail::optional_base<T>
 #endif
 
     void swap( optional & arg )
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+      BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         // allow for Koenig lookup
         boost::swap(*this, arg);


### PR DESCRIPTION
This will add support for more compilers implementing the may_alias attribute.

Also this PR converts tabs to spaces in headers.
