### PR TITLE
Remove deprecation mark from `reset()`

### DIFF
--- a/doc/27_ref_optional_synopsis.qbk
+++ b/doc/27_ref_optional_synopsis.qbk
@@ -196,10 +196,9 @@ They are empty, trivially copyable classes with disabled default constructor.
 
         bool operator!() const noexcept ; ``[link reference_optional_operator_not __GO_TO__]``
 
-        // deprecated methods
-
-        // (deprecated)
         void reset() noexcept ; ``[link reference_optional_reset __GO_TO__]``
+
+        // deprecated methods
 
         // (deprecated)
         void reset ( T const& ) ; ``[link reference_optional_reset_value __GO_TO__]``

--- a/doc/28_ref_optional_semantics.qbk
+++ b/doc/28_ref_optional_semantics.qbk
@@ -541,7 +541,7 @@ __SPACE__
 [#reference_optional_reset]
 
 [: `void optional<T>::reset() noexcept ;`]
-* [*Deprecated:] Same as `operator=( none_t );`
+* [*Effects:] Same as `operator=( none_t );`
 
 __SPACE__
 
@@ -1129,8 +1129,7 @@ __SPACE__
 
 [#reference_optional_ref_reset]
 [: `void optional<T&>::reset() noexcept;`]
-* [*Effects:] Use `*this = none` instead.
-* [*Remarks:] This function is depprecated.
+* [*Effects:] Same as `*this = none`.
 
 __SPACE__
 

--- a/doc/91_relnotes.qbk
+++ b/doc/91_relnotes.qbk
@@ -11,6 +11,10 @@
 
 [section:relnotes Release Notes]
 
+[heading Boost Release 1.69]
+
+* Remove deprecation mark from `reset()` method (without arguments).
+
 [heading Boost Release 1.68]
 
 * Added member function `has_value()` for compatibility with `std::optional` ([@https://github.com/boostorg/optional/issues/52 issue #52]).

--- a/include/boost/optional/detail/old_optional_implementation.hpp
+++ b/include/boost/optional/detail/old_optional_implementation.hpp
@@ -332,7 +332,7 @@ class optional_base : public optional_tag
 
   public :
 
-    // **DEPPRECATED** Destroys the current value, if any, leaving this UNINITIALIZED
+    // Destroys the current value, if any, leaving this UNINITIALIZED
     // No-throw (assuming T::~T() doesn't)
     void reset() BOOST_NOEXCEPT { destroy(); }
 

--- a/include/boost/optional/detail/optional_trivially_copyable_base.hpp
+++ b/include/boost/optional/detail/optional_trivially_copyable_base.hpp
@@ -127,7 +127,7 @@ class tc_optional_base : public optional_tag
 
   public :
 
-    // **DEPPRECATED** Destroys the current value, if any, leaving this UNINITIALIZED
+    // Destroys the current value, if any, leaving this UNINITIALIZED
     // No-throw (assuming T::~T() doesn't)
     void reset() BOOST_NOEXCEPT { destroy(); }
 

--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -378,7 +378,7 @@ class optional_base : public optional_tag
 
   public :
 
-    // **DEPPRECATED** Destroys the current value, if any, leaving this UNINITIALIZED
+    // Destroys the current value, if any, leaving this UNINITIALIZED
     // No-throw (assuming T::~T() doesn't)
     void reset() BOOST_NOEXCEPT { destroy(); }
 


### PR DESCRIPTION
The `std::optional` has `reset()`<sup>[\[optional.mod\]](http://eel.is/c++draft/optional.mod)</sup> and it is not deprecated.

Fixes #61.