### PR TITLE
Conditional construction from InPlaceFactory types.

### DIFF
--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -222,6 +222,15 @@ class optional_base : public optional_tag
       construct(boost::forward<Expr>(expr),tag);
     }
 
+    template<class Expr, class PtrExpr>
+    optional_base ( bool cond, Expr&& expr, PtrExpr const* tag )
+      :
+      m_initialized(false)
+    {
+      if ( cond )
+        construct(boost::forward<Expr>(expr),tag);
+    }
+
 #else
     // This is used for both converting and in-place constructions.
     // Derived classes use the 'tag' to select the appropriate
@@ -232,6 +241,15 @@ class optional_base : public optional_tag
       m_initialized(false)
     {
       construct(expr,tag);
+    }
+
+    template<class Expr>
+    optional_base ( bool cond, Expr const& expr, Expr const* tag )
+      :
+      m_initialized(false)
+    {
+      if ( cond )
+        construct(expr,tag);
     }
 
 #endif
@@ -948,9 +966,20 @@ class optional
     : base(boost::forward<Expr>(expr),boost::addressof(expr))
     {}
 
+  template<class Expr>
+  optional ( bool cond,
+             Expr&& expr,
+             BOOST_DEDUCED_TYPENAME boost::enable_if< optional_detail::is_optional_val_init_candidate<T, Expr>, bool>::type = true
+  )
+    : base(cond,boost::forward<Expr>(expr),boost::addressof(expr))
+    {}
+
 #else
     template<class Expr>
     explicit optional ( Expr const& expr ) : base(expr,boost::addressof(expr)) {}
+
+    template<class Expr>
+    optional ( bool cond, Expr const& expr ) : base(cond,expr,boost::addressof(expr)) {}
 #endif // !defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
 #endif // !defined BOOST_OPTIONAL_NO_INPLACE_FACTORY_SUPPORT
 

--- a/test/optional_test_inplace_factory.cpp
+++ b/test/optional_test_inplace_factory.cpp
@@ -49,16 +49,21 @@ void test_ctor()
   boost::optional<Guard> og1 ( boost::in_place(1.0, "one") );
   boost::optional<Guard> og1_( boost::in_place(1.0, "one") );
   boost::optional<Guard> og2 ( boost::in_place<Guard>(2.0, "two") );
+  boost::optional<Guard> og3 ( true, boost::in_place() );
+  boost::optional<Guard> og4 ( false, boost::in_place() );
   
   BOOST_TEST(og0);
   BOOST_TEST(og1);
   BOOST_TEST(og1_);
   BOOST_TEST(og2);
+  BOOST_TEST(og3);
+  BOOST_TEST(!og4);
   
   BOOST_TEST(*og0  == g0);
   BOOST_TEST(*og1  == g1);
   BOOST_TEST(*og1_ == g1);
   BOOST_TEST(*og2  == g2);
+  BOOST_TEST(*og3  == g0);
   
   BOOST_TEST(og1_ == og1);
   BOOST_TEST(og1_ != og2);


### PR DESCRIPTION
Add overloads to enable conditional construction from InPlaceFactory
types. This is more flexible than in_place_init_if_t since the
parameters to the called constructor do not need to be available in case
the condition is false.

For example:
```
template<class F> struct in_place : F, boost::in_place_factory_base {
    template<class T> void apply(void* p) { F::operator()(static_cast<T*>(p)); }
};
template<class F> in_place(F) -> in_place<F>;
boost::optional<std::string> s = ...;
boost::optional<boost::filesystem::path> p{!!s, in_place{[&]<class T>(void* p) { new (p) T(*s); }}};
```