### PR TITLE
Mark none instances as inline variables

### DIFF
--- a/include/boost/none.hpp
+++ b/include/boost/none.hpp
@@ -13,7 +13,8 @@
 #ifndef BOOST_NONE_17SEP2003_HPP
 #define BOOST_NONE_17SEP2003_HPP
 
-#include "boost/none_t.hpp"
+#include <boost/config.hpp>
+#include <boost/none_t.hpp>
 
 // NOTE: Borland users have to include this header outside any precompiled headers
 // (bcc<=5.64 cannot include instance data in a precompiled header)
@@ -23,7 +24,7 @@ namespace boost {
 
 #ifdef BOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE
 
-none_t const none = (static_cast<none_t>(0)) ;
+BOOST_INLINE_VARIABLE none_t const none = (static_cast<none_t>(0)) ;
 
 #elif defined BOOST_OPTIONAL_USE_SINGLETON_DEFINITION_OF_NONE
 
@@ -35,7 +36,7 @@ namespace detail { namespace optional_detail {
   {
     static const T instance;
   };
-  
+
   template <typename T>
   const T none_instance<T>::instance = T(); // global, but because 'tis a template, no cpp file required
 
@@ -49,7 +50,7 @@ namespace {
 
 #else
 
-const none_t none ((none_t::init_tag()));
+BOOST_INLINE_VARIABLE const none_t none ((none_t::init_tag()));
 
 #endif // older definitions
 


### PR DESCRIPTION
This should avoid duplicating `none` instances in all translation units.

Closes https://github.com/boostorg/optional/issues/33.