### PR TITLE
Optimize includes

### DIFF
--- a/include/boost/optional/detail/old_optional_implementation.hpp
+++ b/include/boost/optional/detail/old_optional_implementation.hpp
@@ -894,7 +894,7 @@ class optional : public optional_detail::optional_base<T>
       BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         // allow for Koenig lookup
-        boost::swap(*this, arg);
+        boost::adl_move_swap(*this, arg);
       }
 
 

--- a/include/boost/optional/detail/optional_swap.hpp
+++ b/include/boost/optional/detail/optional_swap.hpp
@@ -13,7 +13,7 @@
 #ifndef BOOST_OPTIONAL_DETAIL_OPTIONAL_SWAP_AJK_28JAN2015_HPP
 #define BOOST_OPTIONAL_DETAIL_OPTIONAL_SWAP_AJK_28JAN2015_HPP
 
-#include <boost/core/swap.hpp>
+#include <boost/move/adl_move_swap.hpp> // for boost::adl_move_swap
 #include <boost/optional/optional_fwd.hpp>
 
 namespace boost {
@@ -40,7 +40,7 @@ struct swap_selector<true>
             y.emplace();
 
         // Boost.Utility.Swap will take care of ADL and workarounds for broken compilers
-        boost::swap(x.get(), y.get());
+        boost::adl_move_swap(x.get(), y.get());
 
         if( !hasX )
             y = boost::none ;
@@ -64,13 +64,13 @@ struct swap_selector<false>
 {
     template <class T>
     static void optional_swap ( optional<T>& x, optional<T>& y ) 
-    //BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && BOOST_NOEXCEPT_EXPR(boost::swap(*x, *y)))
+    //BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && BOOST_NOEXCEPT_EXPR(boost::adl_move_swap(*x, *y)))
     {
         if (x)
         {
             if (y)
             {
-                boost::swap(*x, *y);
+                boost::adl_move_swap(*x, *y);
             }
             else
             {
@@ -105,7 +105,7 @@ struct optional_swap_should_use_default_constructor : has_nothrow_default_constr
 
 template <class T>
 inline void swap ( optional<T>& x, optional<T>& y )
-//BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && BOOST_NOEXCEPT_EXPR(boost::swap(*x, *y)))
+//BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && BOOST_NOEXCEPT_EXPR(boost::adl_move_swap(*x, *y)))
 {
     optional_detail::swap_selector<optional_swap_should_use_default_constructor<T>::value>::optional_swap(x, y);
 }

--- a/include/boost/optional/optional.hpp
+++ b/include/boost/optional/optional.hpp
@@ -28,7 +28,6 @@
 #include <boost/core/addressof.hpp>
 #include <boost/core/enable_if.hpp>
 #include <boost/core/explicit_operator_bool.hpp>
-#include <boost/core/swap.hpp>
 #include <boost/optional/bad_optional_access.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/throw_exception.hpp>
@@ -50,7 +49,8 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_volatile.hpp>
 #include <boost/type_traits/is_scalar.hpp>
-#include <boost/move/utility.hpp>
+#include <boost/move/adl_move_swap.hpp> // for boost::adl_move_swap
+#include <boost/move/utility_core.hpp> // for boost::move, boost::forward
 #include <boost/none.hpp>
 #include <boost/utility/compare_pointees.hpp>
 #include <boost/utility/result_of.hpp>
@@ -1196,7 +1196,7 @@ class optional
       BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         // allow for Koenig lookup
-        boost::swap(*this, arg);
+        boost::adl_move_swap(*this, arg);
       }
 
 


### PR DESCRIPTION
Swap from Boost.Move includes less headers, giving 6-12% speed-up.

```
clang-cl 0.48 -> 0.45 (6%)
mingw    0.43 -> 0.38 (12%)
```
