### PR TITLE
CI & GCC 4.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ matrix:
             - llvm-toolchain-precise-3.9
 
     - os: linux
+      dist: trusty
       compiler: clang++-4.0
       env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=03,11,14,1z
       addons:
@@ -162,6 +163,7 @@ matrix:
             - llvm-toolchain-trusty-4.0
 
     - os: linux
+      dist: trusty
       compiler: clang++-5.0
       env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03,11,14,1z
       addons:

--- a/include/boost/optional/detail/optional_trivially_copyable_base.hpp
+++ b/include/boost/optional/detail/optional_trivially_copyable_base.hpp
@@ -359,7 +359,7 @@ class tc_optional_base : public optional_tag
     template<class Expr>
     void construct ( Expr const& factory, in_place_factory_base const* )
      {
-       boost_optional_detail::construct<value_type>(factory, m_storage.address());
+       boost_optional_detail::construct<value_type>(factory, boost::addressof(m_storage));
        m_initialized = true ;
      }
 

--- a/test/optional_test_constructible_from_other.cpp
+++ b/test/optional_test_constructible_from_other.cpp
@@ -26,12 +26,14 @@ struct size_tag {};
 template< typename T, typename U >
 struct is_constructible
 {
-    template< typename T1, typename U1 >
-    static yes_type check_helper(size_tag< sizeof(static_cast< T1 >(U1())) >*);
-    template< typename T1, typename U1 >
+    static U& get();
+
+    template< typename T1 >
+    static yes_type check_helper(size_tag< sizeof(static_cast< T1 >(get())) >*);
+    template< typename T1 >
     static no_type check_helper(...);
 
-    static const bool value = sizeof(check_helper< T, U >(0)) == sizeof(yes_type);
+    static const bool value = sizeof(check_helper< T >(0)) == sizeof(yes_type);
 };
 
 template< typename T >

--- a/test/optional_test_inplace_factory.cpp
+++ b/test/optional_test_inplace_factory.cpp
@@ -63,6 +63,9 @@ void test_ctor()
   BOOST_TEST(og1_ == og1);
   BOOST_TEST(og1_ != og2);
   BOOST_TEST(og1_ != og0);
+
+  boost::optional<unsigned int> o( boost::in_place(5) );
+  BOOST_TEST(o && (*o == 5));
 #endif 
 }
 
@@ -92,6 +95,10 @@ void test_assign()
   BOOST_TEST(og1_ == og1);
   BOOST_TEST(og1_ != og2);
   BOOST_TEST(og1_ != og0);
+
+  boost::optional<unsigned int> o;
+  o = boost::in_place(5);
+  BOOST_TEST(o && (*o == 5));
 #endif
 #endif
 }

--- a/test/optional_test_path_assignment.cpp
+++ b/test/optional_test_path_assignment.cpp
@@ -15,6 +15,8 @@
 #pragma hdrstop
 #endif
 
+#ifndef BOOST_OPTIONAL_DETAIL_NO_IS_CONSTRUCTIBLE_TRAIT
+#ifndef BOOST_OPTIONAL_DETAIL_NO_SFINAE_FRIENDLY_CONSTRUCTORS
 template <typename, typename>
 struct void_t
 {
@@ -42,6 +44,8 @@ struct Path
     template <typename T, typename = BOOST_DEDUCED_TYPENAME trait<T>::value_type>
         Path(T const&);
 };
+#endif
+#endif
 
 
 int main()

--- a/test/optional_test_ref_converting_ctor.cpp
+++ b/test/optional_test_ref_converting_ctor.cpp
@@ -93,7 +93,9 @@ template <typename T>
 void test_all_const_cases()
 {
   test_converting_ctor<T>();
+#ifndef BOOST_OPTIONAL_CONFIG_NO_PROPER_CONVERT_FROM_CONST_INT
   test_converting_ctor<const T>();
+#endif
   test_converting_ctor_for_noconst_const<T>();
 }
 


### PR DESCRIPTION
- Fixed an issue with `.travis.yml` which was causing CI to fail for Clang 5
- Unit tests now build & pass under GCC 4.4.7
- Fixed a compile issue encountered under GCC 4.4.7 when assigning to a `boost::optional<T>` where `T` was trivially copyable