### PR TITLE
Add explicit <string> include to make tests compile with MSVC

### DIFF
--- a/test/optional_test_emplace.cpp
+++ b/test/optional_test_emplace.cpp
@@ -15,6 +15,7 @@
 #pragma hdrstop
 #endif
 
+#include <string>
 #include "boost/core/lightweight_test.hpp"
 #include "boost/none.hpp"
 

--- a/test/optional_test_minimum_requirements.cpp
+++ b/test/optional_test_minimum_requirements.cpp
@@ -15,6 +15,7 @@
 #pragma hdrstop
 #endif
 
+#include <string>
 #include "boost/core/lightweight_test.hpp"
 #include "boost/none.hpp"
 


### PR DESCRIPTION
Small portability fix for some tests that relied on `<iostream>` including `<string>`.