### PR TITLE
Change aligned_storage::dummy::data to unsigned char[]

### DIFF
--- a/include/boost/optional/detail/optional_aligned_storage.hpp
+++ b/include/boost/optional/detail/optional_aligned_storage.hpp
@@ -28,7 +28,7 @@ class aligned_storage
     // BOOST_MAY_ALIAS works around GCC warnings about breaking strict aliasing rules when casting storage address to T*
     union BOOST_MAY_ALIAS dummy_u
     {
-        char data[ sizeof(T) ];
+        unsigned char data[ sizeof(T) ];
         BOOST_DEDUCED_TYPENAME type_with_alignment<
           ::boost::alignment_of<T>::value >::type aligner_;
     } dummy_ ;


### PR DESCRIPTION
The standard says in https://eel.is/c++draft/basic.memobj#intro.object-3 that arrays of `unsigned char` or arrays of `std::byte` can _provide storage_, but it doesn't say anything about arrays of `char`.

To be on the safe side, we should use `unsigned char` in `aligned_storage`.

(For context, please see thread starting at https://lists.boost.org/Archives/boost/2022/02/252503.php.)

There's the separate question of whether returning the address of `dummy_`, as done in the may-alias case, is correct per the standard. It probably isn't, but since we're marking the union with may-alias, we're outside the standard proper, so it's not possible to tell. I haven't touched this part.