### PR TITLE
Use `is_same` from Boost.TypeTraits.

### DIFF
--- a/test/optional_test_flat_map.cpp
+++ b/test/optional_test_flat_map.cpp
@@ -16,14 +16,14 @@
 #endif
 
 #include "boost/core/ignore_unused.hpp"
-#include "boost/core/is_same.hpp"
 #include "boost/core/lightweight_test.hpp"
 #include "boost/core/lightweight_test_trait.hpp"
+#include "boost/type_traits/is_same.hpp"
 
 
 using boost::optional;
 using boost::make_optional;
-using boost::core::is_same;
+using boost::is_same;
 
 template <typename Expected, typename Deduced>
 void verify_type(Deduced)

--- a/test/optional_test_make_optional.cpp
+++ b/test/optional_test_make_optional.cpp
@@ -16,21 +16,21 @@
 #endif
 
 #include "boost/core/ignore_unused.hpp"
-#include "boost/core/is_same.hpp"
 #include "boost/core/lightweight_test.hpp"
 #include "boost/core/lightweight_test_trait.hpp"
+#include "boost/type_traits/is_same.hpp"
 
 
 using boost::optional;
 using boost::make_optional;
-using boost::core::is_same;
+using boost::is_same;
 
 template <typename Expected, typename Deduced>
 void verify_type(Deduced)
 {
   BOOST_TEST_TRAIT_TRUE(( is_same<Expected, Deduced> ));
 }
-  
+
 #if (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES)
 struct MoveOnly
 {
@@ -38,7 +38,7 @@ struct MoveOnly
   explicit MoveOnly(int i) : value(i) {}
   MoveOnly(MoveOnly && r) : value(r.value) { r.value = 0; }
   MoveOnly& operator=(MoveOnly && r) { value = r.value; r.value = 0; return *this; }
-  
+
 private:
   MoveOnly(MoveOnly const&);
   void operator=(MoveOnly const&);
@@ -53,15 +53,15 @@ void test_make_optional_for_move_only_type()
 {
   verify_type< optional<MoveOnly> >(make_optional(makeMoveOnly(2)));
   verify_type< optional<MoveOnly> >(make_optional(true, makeMoveOnly(2)));
-  
+
   optional<MoveOnly> o1 = make_optional(makeMoveOnly(1));
   BOOST_TEST (o1);
   BOOST_TEST_EQ (1, o1->value);
-  
+
   optional<MoveOnly> o2 = make_optional(true, makeMoveOnly(2));
   BOOST_TEST (o2);
   BOOST_TEST_EQ (2, o2->value);
-  
+
   optional<MoveOnly> oN = make_optional(false, makeMoveOnly(2));
   BOOST_TEST (!oN);
 }
@@ -73,15 +73,15 @@ void test_make_optional_for_optional()
   optional<int> oi;
   verify_type< optional< optional<int> > >(make_optional(oi));
   verify_type< optional< optional<int> > >(make_optional(true, oi));
-  
+
   optional< optional<int> > ooi = make_optional(oi);
   BOOST_TEST (ooi);
   BOOST_TEST (!*ooi);
-  
+
   optional< optional<int> > ooT = make_optional(true, oi);
   BOOST_TEST (ooT);
   BOOST_TEST (!*ooT);
-  
+
   optional< optional<int> > ooF = make_optional(false, oi);
   BOOST_TEST (!ooF);
 }
@@ -90,21 +90,21 @@ void test_nested_make_optional()
 {
   verify_type< optional< optional<int> > >(make_optional(make_optional(1)));
   verify_type< optional< optional<int> > >(make_optional(true, make_optional(true, 2)));
-  
+
   optional< optional<int> > oo1 = make_optional(make_optional(1));
   BOOST_TEST (oo1);
   BOOST_TEST (*oo1);
   BOOST_TEST_EQ (1, **oo1);
-  
+
   optional< optional<int> > oo2 = make_optional(true, make_optional(true, 2));
   BOOST_TEST (oo2);
   BOOST_TEST (*oo2);
   BOOST_TEST_EQ (2, **oo2);
-  
+
   optional< optional<int> > oo3 = make_optional(true, make_optional(false, 3));
   BOOST_TEST (oo3);
   BOOST_TEST (!*oo3);
-  
+
   optional< optional<int> > oo4 = make_optional(false, make_optional(true, 4));
   BOOST_TEST (!oo4);
 }

--- a/test/optional_test_map.cpp
+++ b/test/optional_test_map.cpp
@@ -16,29 +16,29 @@
 #endif
 
 #include "boost/core/ignore_unused.hpp"
-#include "boost/core/is_same.hpp"
 #include "boost/core/lightweight_test.hpp"
 #include "boost/core/lightweight_test_trait.hpp"
+#include "boost/type_traits/is_same.hpp"
 
 
 using boost::optional;
 using boost::make_optional;
-using boost::core::is_same;
+using boost::is_same;
 
 template <typename Expected, typename Deduced>
 void verify_type(Deduced)
 {
   BOOST_TEST_TRAIT_TRUE(( is_same<Expected, Deduced> ));
 }
-  
-#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES) 
+
+#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES)
 struct MoveOnly
 {
   int value;
   explicit MoveOnly(int i) : value(i) {}
   MoveOnly(MoveOnly && r) : value(r.value) { r.value = 0; }
   MoveOnly& operator=(MoveOnly && r) { value = r.value; r.value = 0; return *this; }
-  
+
 private:
   MoveOnly(MoveOnly const&);
   void operator=(MoveOnly const&);
@@ -70,7 +70,7 @@ void test_map_move_only()
   optional<int> oj = makeOptMoveOnly(4).map(get_val);
   BOOST_TEST(bool(oj));
   BOOST_TEST_EQ(4, *oj);
-  
+
   optional<MoveOnly> o_;
   optional<int> oi_ = boost::move(o_).map(get_val);
   BOOST_TEST(!oi_);
@@ -126,16 +126,16 @@ void test_map_optional()
   optional<int> o9 (9), o0 (0), o_;
   verify_type<optional<optional<Int> > >(o9.map(make_opt_int));
   optional<optional<Int> > oo9 = o9.map(make_opt_int);
-  BOOST_TEST(bool(oo9));  
-  BOOST_TEST(bool(*oo9));  
+  BOOST_TEST(bool(oo9));
+  BOOST_TEST(bool(*oo9));
   BOOST_TEST_EQ(9, (**oo9).i);
 
   optional<optional<Int> > oo0 = o0.map(make_opt_int);
-  BOOST_TEST(bool(oo0));  
-  BOOST_TEST(!*oo0);  
-  
+  BOOST_TEST(bool(oo0));
+  BOOST_TEST(!*oo0);
+
   optional<optional<Int> > oo_ = o_.map(make_opt_int);
-  BOOST_TEST(!oo_);  
+  BOOST_TEST(!oo_);
 }
 
 void test_map_with_lambda()
@@ -178,7 +178,7 @@ void test_map_optional_ref()
 
 int main()
 {
-#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES) 
+#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES)
   test_map_move_only();
 #endif
   test_map_with_lambda();


### PR DESCRIPTION
`boost::core::is_same` is deprecated, so use the one from Boost.TypeTraits instead.