### PR TITLE
Fix doc warnings

### DIFF
--- a/doc/23_ref_optional_io.qbk
+++ b/doc/23_ref_optional_io.qbk
@@ -41,10 +41,11 @@ template<class CharType, class CharTrait, class T>
 
 [#reference_operator_ostream]
 
-
-`template <class CharType, class CharTrait, class T>` [br]
- std::basic_ostream<CharType, CharTrait>&` [br]
- operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<T> const& v);`
+```
+template <class CharType, class CharTrait, class T>
+std::basic_ostream<CharType, CharTrait>&
+operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<T> const& v);
+```
 
 * [*Effect:] Outputs an implementation-defined string. The output contains the information about whether the optional object contains a value or not. If `v` contains a value, the output contains result of calling `out << *v`.
 * [*Returns:] `out`.
@@ -52,9 +53,11 @@ template<class CharType, class CharTrait, class T>
 __SPACE__
 [#reference_operator_ostream_none]
 
-`template <class CharType, class CharTrait, class T>` [br]
- std::basic_ostream<CharType, CharTrait>&` [br]
- operator<<(std::basic_ostream<CharType, CharTrait>& out, none_t);`
+```
+template <class CharType, class CharTrait, class T>
+std::basic_ostream<CharType, CharTrait>&
+operator<<(std::basic_ostream<CharType, CharTrait>& out, none_t);
+```
 
 * [*Effect:] Outputs an implementation-defined string.
 * [*Returns:] `out`.
@@ -62,9 +65,11 @@ __SPACE__
 __SPACE__
 [#reference_operator_istream]
 
-`template <class CharType, class CharTrait, class T>` [br]
- std::basic_ostream<CharType, CharTrait>&` [br]
- operator>>(std::basic_istream<CharType, CharTrait>& in, optional<T>& v);`
+```
+template <class CharType, class CharTrait, class T>
+std::basic_ostream<CharType, CharTrait>&
+operator>>(std::basic_istream<CharType, CharTrait>& in, optional<T>& v);
+```
 
 * [*Requires:] `T` is __STD_DEFAULT_CONSTRUCTIBLE__ and __MOVE_CONSTRUCTIBLE__.
 * [*Effect:] Reads the value of optional object from `in`. If the string representation indicates that the optional object should contain a value, `v` contains a value and its contained value is obtained as if by default-constructing an object `o` of type `T` and then calling `in >> o`; otherwise `v` does not contain a value, and the previously contained value (if any) has been destroyed.

--- a/doc/28_ref_optional_semantics.qbk
+++ b/doc/28_ref_optional_semantics.qbk
@@ -1428,9 +1428,9 @@ struct hash<boost::optional<T&> > ;
 ``
 
 The specialization `hash<optional<T>>` is enabled if and only if
-`hash<remove_­const_­t<T>>` is enabled. When enabled, for an object `o`
-of type `optional<T>`, if `o.has_­value() == true`, then `hash<optional<T>>()(o)`
- evaluates to the same value as `hash<remove_­const_­t<T>>()(*o)`; otherwise it
+`hash<remove_const_t<T>>` is enabled. When enabled, for an object `o`
+of type `optional<T>`, if `o.has_value() == true`, then `hash<optional<T>>()(o)`
+ evaluates to the same value as `hash<remove_const_t<T>>()(*o)`; otherwise it
 evaluates to an unspecified value.
 The member functions are not guaranteed to be `noexcept`.
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -29,20 +29,20 @@ install images
     :
         <location>html/images
     ;
-        
+
 boostbook standalone
     :
         optional
     :
-        <format>html:<xsl:param>boost.root=../../../..
-        <format>html:<xsl:param>boost.libraries=../../../../libs/libraries.htm
-        <xsl:param>chapter.autolabel=0
-        <xsl:param>chunk.section.depth=8
-        <xsl:param>toc.section.depth=2
-        <xsl:param>toc.max.depth=2
-        <xsl:param>generate.section.toc.level=1
-        <format>pdf:<xsl:param>img.src.path=$(images)/
-        <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/libs/optional/doc/html
+        <format>html:<xsl:param>"boost.root=../../../.."
+        <format>html:<xsl:param>"boost.libraries=../../../../libs/libraries.htm"
+        <xsl:param>"chapter.autolabel=0"
+        <xsl:param>"chunk.section.depth=8"
+        <xsl:param>"toc.section.depth=2"
+        <xsl:param>"toc.max.depth=2"
+        <xsl:param>"generate.section.toc.level=1"
+        <format>pdf:<xsl:param>"img.src.path=$(images)/"
+        <format>pdf:<xsl:param>"boost.url.prefix=http://www.boost.org/doc/libs/release/libs/optional/doc/html"
         <format>docbook:<auto-index-internal>on
     ;
 


### PR DESCRIPTION
A few commits that fix a few warnings produced when building docs:

- `b2` warning about using reserved characters in parameter values
- QuickBook warnings about invalid characters
- QuickBook warnings about line breaks potentially producing invalid Boost.Book output. Also fixes broken output for IO operator reference.

None of these are "fatal" errors, i.e. the docs are building successfully even with the warnings. But worth fixing anyway.
