### PR TITLE
Fix ununsed parameter warning

### DIFF
--- a/include/boost/optional/detail/optional_relops.hpp
+++ b/include/boost/optional/detail/optional_relops.hpp
@@ -134,7 +134,7 @@ bool operator == ( optional<T> const& x, none_t ) BOOST_NOEXCEPT
 
 template<class T>
 inline
-bool operator < ( optional<T> const& x, none_t )
+bool operator < ( optional<T> const&, none_t )
 { return false; }
 
 template<class T>


### PR DESCRIPTION
The function returns false w/o using any parameter leading to a warning. Remove the name from the parameter