### PR TITLE
Add C++11 requirements to build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             address-model: 32,64
           - toolset: gcc-11
             cxxstd: "03,11,14,17,20"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             install: g++-11-multilib
             address-model: 32,64
           - toolset: gcc-12

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(boost_optional
     Boost::throw_exception
     Boost::type_traits
 )
+target_compile_features(boost_optional INTERFACE cxx_std_11)
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2003, Fernando Luis Cacciola Carballal.
 # Copyright (C) 2014 - 2017 Andrzej Krzemienski
+# Copyright (C) 2024 Alexander Grund
 #
 # Use, modification, and distribution is subject to the Boost Software
 # License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -13,7 +14,23 @@
 #  akrzemi1@gmail.com
 #
 
+import config : requires ;
 import testing ;
+
+project
+    : requirements
+        [ requires
+            cxx11_decltype
+            cxx11_defaulted_functions
+            cxx11_defaulted_moves
+            cxx11_deleted_functions
+            cxx11_explicit_conversion_operators
+            cxx11_noexcept
+            cxx11_rvalue_references
+            cxx11_variadic_templates
+        ]
+    ;
+
 
 run optional_test.cpp ;
 run optional_test_assign.cpp ;


### PR DESCRIPTION
As the library now requires C++11 since https://github.com/boostorg/optional/commit/82d08adf119d9fd2f99fe02d25ff4c5895bb4a6e the tests e.g. on CI fail with C++03.

Add the C++11 requirement to Jamefile and CMakeLists. The list of features in the Jamfile is mirroring the condition leading to the explicit error in[ `boost/none_t.hpp`](https://github.com/boostorg/optional/blob/develop/include/boost/none_t.hpp#L18-L19)

cc @pdimov for the GHA fix after 5c34c54b05923ee9bba9957f2fa68a9027fe628e