### PR TITLE
GHA: Remove macos-11 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,6 @@ jobs:
             os: ubuntu-latest
             install: clang-17
           - toolset: clang
-            cxxstd: "03,11,14,17,2a"
-            os: macos-11
-          - toolset: clang
             cxxstd: "03,11,14,17,20,2b"
             os: macos-12
           - toolset: clang
@@ -283,7 +280,6 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
           - os: macos-12
           - os: macos-13
 
@@ -331,7 +327,6 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
           - os: macos-12
           - os: macos-13
 
@@ -389,7 +384,6 @@ jobs:
         include:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: macos-11
           - os: macos-12
           - os: macos-13
 


### PR DESCRIPTION
The runners no longer have that so the jobs fail as they never start