### PR TITLE
CML: Create header-only target in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ add_library(boost_optional INTERFACE)
 add_library(Boost::optional ALIAS boost_optional)
 
 target_include_directories(boost_optional INTERFACE include)
+if(NOT CMAKE_VERSION VERSION_LESS "3.19") 
+  file(GLOB_RECURSE headers include/*.hpp)
+  target_sources(boost_optional PRIVATE ${headers})
+endif()
 
 target_link_libraries(boost_optional
   INTERFACE


### PR DESCRIPTION
Since CMake 3.19 it is possible to specify private sources for `INTERFACE` targets. This makes the library turn up like compiled libraries in IDEs such as Visual Studio.

It can also be specified in the `add_library` call but using `target_sources` is more isolated to the CMake version check