### PR TITLE
fix: add -Wmaybe-uninitialized pragma to union storage constructors

### DIFF
--- a/include/boost/optional/detail/union_optional.hpp
+++ b/include/boost/optional/detail/union_optional.hpp
@@ -74,8 +74,19 @@ union constexpr_union_storage_t
 
     constexpr constexpr_union_storage_t( trivial_init_t ) noexcept : dummy_() {};
 
+#if defined(BOOST_GCC) && (__GNUC__ >= 7)
+// false positive, see https://github.com/boostorg/variant2/issues/55,
+//   https://github.com/boostorg/url/issues/979
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
     template <class... Args>
     constexpr constexpr_union_storage_t( Args&&... args ) : value_(forward_<Args>(args)...) {}
+
+#if defined(BOOST_GCC) && (__GNUC__ >= 7)
+# pragma GCC diagnostic pop
+#endif
 
     //~constexpr_union_storage_t() = default; // No need to destroy a trivially-destructible type
 };
@@ -88,8 +99,19 @@ union fallback_union_storage_t
 
   constexpr fallback_union_storage_t( trivial_init_t ) noexcept : dummy_() {};
 
+#if defined(BOOST_GCC) && (__GNUC__ >= 7)
+// false positive, see https://github.com/boostorg/variant2/issues/55,
+//   https://github.com/boostorg/url/issues/979
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
   template <class... Args>
   constexpr fallback_union_storage_t( Args&&... args ) : value_(forward_<Args>(args)...) {}
+
+#if defined(BOOST_GCC) && (__GNUC__ >= 7)
+# pragma GCC diagnostic pop
+#endif
 
   ~fallback_union_storage_t(){} // My owner will destroy the `T` if needed.
                                 // Cannot default in a union with nontrivial `T`.


### PR DESCRIPTION
GCC 7+ at `-O3` produces false-positive `-Wmaybe-uninitialized` warnings when inlining through the `constexpr_union_storage_t` and `fallback_union_storage_t` constructors. Same class of false positive as boostorg/variant2#55 — union with a dummy and value member, constructor initializes value.

Adds scoped pragmas around both forwarding constructors in `union_optional.hpp`.

Refs https://github.com/boostorg/url/pull/981