### PR TITLE
Fix C&P issue int test of bool-likes in optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:

--- a/test/optional_test_constructors.cpp
+++ b/test/optional_test_constructors.cpp
@@ -27,7 +27,7 @@ struct MyBool
 struct MyExplicitBool
 {
   bool b;
-  MyExplicitBool (bool b) : b(b) {}
+  explicit MyExplicitBool (bool b) : b(b) {}
   operator bool() const { return b; };
 };
 


### PR DESCRIPTION
This was likely an omission by copying `MyBool` in 1fb60cb53bb2b86b2a9739a26a8be2c5e4c9e8fc

Currently it is exactly the same so provides not further coverage
If the bool-operator should also be explicit that needs to be added too

@akrzemi1 

BTW: I'd suggest switching to the [reusable Boost.CI workflow](https://github.com/boostorg/boost-ci/blob/master/.github/workflows/ci.yml) There the Clang-16 failure is fixed by [using the container](https://github.com/boostorg/boost-ci/commit/b3b98cab24d4f6256e0f96c722d84396b0b12dc5#diff-b93b9cbdb1dab3ca19b8b73cf6fdec1febcf160e589beaee0454f48d56c335dfL403-R403)